### PR TITLE
Update client to print response body if not json

### DIFF
--- a/cmd/_integration-tests/transport/Makefile
+++ b/cmd/_integration-tests/transport/Makefile
@@ -23,5 +23,13 @@ test:
 	go test -v
 	$(MAKE) clean
 
+# Run this when you add a new rpc to the .proto file and it will update
+# handlers/handlers.go
+newrpc:
+	truss transport-test.proto
+	cp -r handlers transportpermutations-service
+	truss transport-test.proto
+	cp -r transportpermutations-service/handlers/handlers.go handlers
+
 clean:
 	rm -rf transportpermutations-service

--- a/cmd/_integration-tests/transport/handlers/handlers.go
+++ b/cmd/_integration-tests/transport/handlers/handlers.go
@@ -124,3 +124,17 @@ func (s transportpermutationsService) ErrorRPC(ctx context.Context, in *pb.Empty
 func (s transportpermutationsService) X2AOddRPCName(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
 	return in, nil
 }
+
+// ErrorRPCNonJSONLong implements Service.
+func (s transportpermutationsService) ErrorRPCNonJSONLong(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
+	var resp pb.Empty
+	resp = pb.Empty{}
+	return &resp, nil
+}
+
+// ErrorRPCNonJSON implements Service.
+func (s transportpermutationsService) ErrorRPCNonJSON(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
+	var resp pb.Empty
+	resp = pb.Empty{}
+	return &resp, nil
+}

--- a/cmd/_integration-tests/transport/handlers/handlers.go
+++ b/cmd/_integration-tests/transport/handlers/handlers.go
@@ -138,3 +138,10 @@ func (s transportpermutationsService) ErrorRPCNonJSON(ctx context.Context, in *p
 	resp = pb.Empty{}
 	return &resp, nil
 }
+
+// ContentTypeTest implements Service.
+func (s transportpermutationsService) ContentTypeTest(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
+	var resp pb.Empty
+	resp = pb.Empty{}
+	return &resp, nil
+}

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -415,7 +415,7 @@ func TestNonJSONResponseBodyFromClientCallIsInError(t *testing.T) {
 	var req pb.Empty
 	_, err = svchttp.ErrorRPCNonJSON(context.Background(), &req)
 	if err == nil {
-		t.Fatal("Expected error from non json response with http client")
+		t.Fatal("Expected error from non-json response with http client")
 	}
 
 	if !strings.Contains(err.Error(), brokenHTTPResponse) {
@@ -434,7 +434,7 @@ func TestNonJSONResponseBodyFromClientCallPrintsLessThan8KB(t *testing.T) {
 	var req pb.Empty
 	_, err = svchttp.ErrorRPCNonJSONLong(context.Background(), &req)
 	if err == nil {
-		t.Fatal("Expected error from non json response with http client")
+		t.Fatal("Expected error from non-json response with http client")
 	}
 
 	l := len(err.Error())
@@ -443,6 +443,25 @@ func TestNonJSONResponseBodyFromClientCallPrintsLessThan8KB(t *testing.T) {
 		t.Fatalf("Expected error to be less than 8KB with a little padding, actual %d", l)
 	}
 	t.Log("Non JSON response length", l)
+}
+
+func TestResponseContentType(t *testing.T) {
+	req, err := http.NewRequest("GET", httpAddr+"/content/type", strings.NewReader(""))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "cannot construct http request"))
+	}
+
+	client := &http.Client{}
+	httpResp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "cannot make end http request"))
+	}
+	defer httpResp.Body.Close()
+
+	got, want := httpResp.Header.Get("Content-Type"), "application/json"
+	if !strings.HasPrefix(got, want) {
+		t.Fatalf("Expected content type to have `%s` got `%s`", want, got)
+	}
 }
 
 // Helpers
@@ -507,13 +526,13 @@ func testHTTPRequest(req *http.Request) ([]byte, error) {
 	client := &http.Client{}
 	httpResp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot not end http request")
+		return nil, errors.Wrap(err, "cannot make end http request")
 	}
 	defer httpResp.Body.Close()
 
 	respBytes, err := ioutil.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot not read http body")
+		return nil, errors.Wrap(err, "cannot read http body")
 	}
 
 	return respBytes, nil

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -450,7 +450,7 @@ func TestNonJSONResponseBodyFromClientCallIsLessThan8KB(t *testing.T) {
 // body in the error message. To allow for developers to see the request body in the errors.
 func TestNonJSONRequestBodyIsInError(t *testing.T) {
 	// Put some bad data into the body
-	req, err := http.NewRequest("GET", httpAddr+"/error/non/json", strings.NewReader(brokenHTTPRequest))
+	req, err := http.NewRequest("POST", httpAddr+"/error/non/json", strings.NewReader(brokenHTTPRequest))
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "cannot construct http request"))
 	}
@@ -479,7 +479,7 @@ func TestNonJSONRequestBodyIsLessThan8KB(t *testing.T) {
 	for i := 0; i < 8196*2; i++ {
 		badBody = append(badBody, byte(i%256))
 	}
-	req, err := http.NewRequest("GET", httpAddr+"/error/non/json", bytes.NewReader(badBody))
+	req, err := http.NewRequest("POST", httpAddr+"/error/non/json", bytes.NewReader(badBody))
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "cannot construct http request"))
 	}
@@ -512,7 +512,7 @@ func TestResponseContentType(t *testing.T) {
 	client := &http.Client{}
 	httpResp, err := client.Do(req)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "cannot make end http request"))
+		t.Fatal(errors.Wrap(err, "cannot make http request"))
 	}
 	defer httpResp.Body.Close()
 
@@ -584,7 +584,7 @@ func testHTTPRequest(req *http.Request) ([]byte, error) {
 	client := &http.Client{}
 	httpResp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot make end http request")
+		return nil, errors.Wrap(err, "cannot make http request")
 	}
 	defer httpResp.Body.Close()
 

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -352,7 +352,7 @@ func TestGetWithPathParamsRequest_IncompletePath(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"error": "cannot unmarshal path parameters: expected a path containing 4 parts, provided path contains 3 parts",
+		"error": "cannot unmarshal path parameters: expecting a path containing 4 parts, provided path contains 3 parts",
 	}
 	if !reflect.DeepEqual(resp, want) {
 		t.Fatalf("Expect: %v, got %v", want, resp)

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -403,6 +403,10 @@ func TestStrangeRPCName(t *testing.T) {
 	}
 }
 
+// TODO: TestNonJSONRequestBodyIsInError()
+
+// TODO: TestNonJSONRequestBodyIsLessThan8KB()
+
 // Test that if a truss client recieves a non-json response from a "truss"
 // server, that we put that response in the error message, for easier debugging
 // Rather than just getting a json paring error
@@ -425,7 +429,7 @@ func TestNonJSONResponseBodyFromClientCallIsInError(t *testing.T) {
 
 // Test that if a non json response is recieved that is greater than 8KB, that
 // we only put the first 8KB error, as to not flood our logs
-func TestNonJSONResponseBodyFromClientCallPrintsLessThan8KB(t *testing.T) {
+func TestNonJSONResponseBodyFromClientCallIsLessThan8KB(t *testing.T) {
 	svchttp, err := httpclient.New(nonJSONHTTPAddr)
 	if err != nil {
 		t.Fatalf("cannot create httpclient: %q", err)

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -253,7 +253,7 @@ func TestGetWithCapsPathClient(t *testing.T) {
 
 	svchttp, err := httpclient.New(httpAddr)
 	if err != nil {
-		t.Fatalf("failed to create httpclient: %q", err)
+		t.Fatalf("cannot create httpclient: %q", err)
 	}
 
 	resp, err := svchttp.GetWithCapsPath(context.Background(), &req)
@@ -337,18 +337,18 @@ func TestGetWithPathParamsRequest_IncompletePath(t *testing.T) {
 
 	httpReq, err := http.NewRequest("GET", httpAddr+path, strings.NewReader(""))
 	if err != nil {
-		t.Errorf("couldn't create request", err)
+		t.Errorf("cannot create request", err)
 	}
 	respBytes, err := testHTTPRequest(httpReq)
 
 	var resp map[string]string
 	err = json.Unmarshal(respBytes, &resp)
 	if err != nil {
-		t.Fatalf("couldn't unmarshal bytes: %v", err)
+		t.Fatalf("cannot unmarshal bytes: %s", respBytes)
 	}
 
 	want := map[string]string{
-		"error": "couldn't unmarshal path parameters: Expected a path containing 4 parts, provided path contains 3 parts",
+		"error": "cannot unmarshal path parameters: expected a path containing 4 parts, provided path contains 3 parts",
 	}
 	if !reflect.DeepEqual(resp, want) {
 		t.Fatalf("Expect: %v, got %v", want, resp)
@@ -462,13 +462,13 @@ func testHTTPRequest(req *http.Request) ([]byte, error) {
 	client := &http.Client{}
 	httpResp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not end http request")
+		return nil, errors.Wrap(err, "cannot not end http request")
 	}
 	defer httpResp.Body.Close()
 
 	respBytes, err := ioutil.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read http body")
+		return nil, errors.Wrap(err, "cannot not read http body")
 	}
 
 	return respBytes, nil

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strconv"
@@ -75,5 +76,21 @@ func TestMain(m *testing.M) {
 
 	httpAddr = httpTestServer.URL
 	grpcAddr = ":" + strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	// Set up a http server that returns non JSON responses
+	bmux := http.NewServeMux()
+	// Simple non-json response
+	bmux.HandleFunc("/error/non/json", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(brokenHTTPResponse))
+	})
+	// Put 16KB of non-json data into the response body
+	bmux.HandleFunc("/error/non/json/long", func(w http.ResponseWriter, r *http.Request) {
+		for i := 0; i < 8196*2; i++ {
+			w.Write([]byte{byte(i % 256)})
+		}
+	})
+	nonJSONHTTPServer := httptest.NewServer(bmux)
+	nonJSONHTTPAddr = nonJSONHTTPServer.URL
+
 	os.Exit(m.Run())
 }

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -40,7 +40,10 @@ func TestMain(m *testing.M) {
 	getWithEnumPathE := svc.MakeGetWithEnumPathEndpoint(service)
 	echoOddNamesE := svc.MakeEchoOddNamesEndpoint(service)
 	errorRPCE := svc.MakeErrorRPCEndpoint(service)
+	errorRPCNonJSONE := svc.MakeErrorRPCNonJSONEndpoint(service)
+	errorRPCNonJSONLongE := svc.MakeErrorRPCNonJSONLongEndpoint(service)
 	X2AOddRPCNameE := svc.MakeX2AOddRPCNameEndpoint(service)
+	contentTypeTestE := svc.MakeContentTypeTestEndpoint(service)
 
 	endpoints := svc.Endpoints{
 		GetWithQueryEndpoint:              getWithQueryE,
@@ -53,7 +56,10 @@ func TestMain(m *testing.M) {
 		GetWithEnumPathEndpoint:           getWithEnumPathE,
 		EchoOddNamesEndpoint:              echoOddNamesE,
 		ErrorRPCEndpoint:                  errorRPCE,
+		ErrorRPCNonJSONEndpoint:           errorRPCNonJSONE,
+		ErrorRPCNonJSONLongEndpoint:       errorRPCNonJSONLongE,
 		X2AOddRPCNameEndpoint:             X2AOddRPCNameE,
+		ContentTypeTestEndpoint:           contentTypeTestE,
 	}
 
 	ctx := context.Background()

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -75,6 +75,11 @@ service TransportPermutations {
       get: "/oddrpcname"
     };
   }
+  rpc ContentTypeTest (Empty) returns (Empty) {
+    option (google.api.http) = {
+      get: "/content/type"
+    };
+  }
 }
 
 message Empty {}

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -61,12 +61,14 @@ service TransportPermutations {
   }
   rpc ErrorRPCNonJSON (Empty) returns (Empty) {
     option (google.api.http) = {
-      get: "/error/non/json"
+      post: "/error/non/json"
+      body: "*"
     };
   }
   rpc ErrorRPCNonJSONLong (Empty) returns (Empty) {
     option (google.api.http) = {
-      get: "/error/non/json/long"
+      post: "/error/non/json/long"
+      body: "*"
     };
   }
   /* Odd RPC names need to still work */

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -59,6 +59,16 @@ service TransportPermutations {
       get: "/error"
     };
   }
+  rpc ErrorRPCNonJSON (Empty) returns (Empty) {
+    option (google.api.http) = {
+      get: "/error/non/json"
+    };
+  }
+  rpc ErrorRPCNonJSONLong (Empty) returns (Empty) {
+    option (google.api.http) = {
+      get: "/error/non/json/long"
+    };
+  }
   /* Odd RPC names need to still work */
   rpc _2aOddRPCName (Empty) returns (Empty) {
     option (google.api.http) = {

--- a/gengokit/httptransport/embeddable_funcs.go
+++ b/gengokit/httptransport/embeddable_funcs.go
@@ -25,7 +25,7 @@ func PathParams(url string, urlTmpl string) (map[string]string, error) {
 	expectedLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
 	recievedLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
 	if expectedLen != recievedLen {
-		return nil, fmt.Errorf("Expected a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
+		return nil, fmt.Errorf("expected a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
 	}
 
 	parts := strings.Split(url, "/")

--- a/gengokit/httptransport/embeddable_funcs.go
+++ b/gengokit/httptransport/embeddable_funcs.go
@@ -25,7 +25,7 @@ func PathParams(url string, urlTmpl string) (map[string]string, error) {
 	expectedLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
 	recievedLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
 	if expectedLen != recievedLen {
-		return nil, fmt.Errorf("expected a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
+		return nil, fmt.Errorf("expecting a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
 	}
 
 	parts := strings.Split(url, "/")

--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -248,7 +248,7 @@ func errorDecoder(buf []byte) error {
 		if len(buf) > size {
 			buf = buf[:size]
 		}
-		return fmt.Errorf("request body '%s': cannot parse non-json request body", buf)
+		return fmt.Errorf("response body '%s': cannot parse non-json request body", buf)
 	}
 
 	return errors.New(w.Error)

--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -213,12 +213,12 @@ func contextValuesToHttpHeaders(keys []string) httptransport.RequestFunc {
 	// body. Primarily useful in a client.
 	func DecodeHTTP{{$method.Name}}Response(_ context.Context, r *http.Response) (interface{}, error) {
 		buf, err := ioutil.ReadAll(r.Body)
-		if len(buf) == 0 {
-			return nil, errors.New("response http body empty")
-		}
-
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot read http body")
+		}
+
+		if len(buf) == 0 {
+			return nil, errors.New("response http body empty")
 		}
 
 		if r.StatusCode != http.StatusOK {
@@ -255,6 +255,6 @@ func errorDecoder(buf []byte) error {
 }
 
 type errorWrapper struct {
-	Error string ` + "`json:\"error\"`\n" + `
+	Error string ` + "`" + `json:"error"` + "`" + `
 }
 `

--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -222,7 +222,7 @@ func contextValuesToHttpHeaders(keys []string) httptransport.RequestFunc {
 		}
 
 		if r.StatusCode != http.StatusOK {
-			return nil, errorDecoder(buf)
+			return nil, errors.Wrapf(errorDecoder(buf), "status code: '%d'", r.StatusCode)
 		}
 
 		var resp pb.{{GoName $method.ResponseType}}

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -14,9 +14,12 @@ var ServerDecodeTemplate = `
 			return nil, errors.Wrapf(err, "cannot read body of http request")
 		}
 		if len(buf) > 0 {
-			err = json.Unmarshal(buf, &req)
-			if err != nil {
-				return nil, errors.Wrapf(err, "body %s: cannot decode body of http request", buf)
+			if err = json.Unmarshal(buf, &req); err != nil {
+				const size = 8196
+				if len(buf) > size {
+					buf = buf[:size]
+				}
+				return nil, fmt.Errorf("request body '%s': cannot parse non-json request body", buf)
 			}
 		}
 
@@ -185,33 +188,12 @@ func MakeHTTPHandler(ctx context.Context, endpoints Endpoints, logger log.Logger
 	return m
 }
 
-// ErrorEncoder writes the error to the ResponseWriter, by default a content
-// type of application/json, a body of json with key "error" and the value
-// error.Error(), and a status code of 500. If the error implements Headerer,
-// the provided headers will be applied to the response. If the error
-// implements json.Marshaler, and the marshaling succeeds, the JSON encoded
-// form of the error will be used. If the error implements StatusCoder, the
-// provided StatusCode will be used instead of 500.
 func errorEncoder(_ context.Context, err error, w http.ResponseWriter) {
-	contentType := "application/json; charset=utf-8"
-	body, _ := json.Marshal(errorWrapper{Error: err.Error()})
-	if marshaler, ok := err.(json.Marshaler); ok {
-		if jsonBody, marshalErr := marshaler.MarshalJSON(); marshalErr == nil {
-			body = jsonBody
-		}
-	}
-	w.Header().Set("Content-Type", contentType)
-	if headerer, ok := err.(httptransport.Headerer); ok {
-		for k := range headerer.Headers() {
-			w.Header().Set(k, headerer.Headers().Get(k))
-		}
-	}
 	code := http.StatusInternalServerError
-	if sc, ok := err.(httptransport.StatusCoder); ok {
-		code = sc.StatusCode()
-	}
+	msg := err.Error()
+
 	w.WriteHeader(code)
-	w.Write(body)
+	json.NewEncoder(w).Encode(errorWrapper{Error: msg})
 }
 
 type errorWrapper struct {

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -62,7 +62,7 @@ func PathParams(url string, urlTmpl string) (map[string]string, error) {
 	expectedLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
 	recievedLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
 	if expectedLen != recievedLen {
-		return nil, fmt.Errorf("expected a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
+		return nil, fmt.Errorf("expecting a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
 	}
 
 	parts := strings.Split(url, "/")

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -212,7 +212,7 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 
 // Test that all the templated source code is identical to the source code
 // found within the file 'embeddable_funcs.go'.
-func _TestHTTPAssistFuncs(t *testing.T) {
+func TestHTTPAssistFuncs(t *testing.T) {
 	tmplfncs := FormatCode(templates.HTTPAssistFuncs)
 	// Get the source code for all the functions in the same source file as
 	// the BuildParamMap function

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -113,7 +113,7 @@ func EncodeHTTPSumZeroRequest(_ context.Context, r *http.Request, request interf
 	}
 }
 
-func TestGenServerDecode(t *testing.T) {
+func _TestGenServerDecode(t *testing.T) {
 	binding := &Binding{
 		Label:        "SumZero",
 		PathTemplate: "/sum/{a}",
@@ -212,7 +212,7 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 
 // Test that all the templated source code is identical to the source code
 // found within the file 'embeddable_funcs.go'.
-func TestHTTPAssistFuncs(t *testing.T) {
+func _TestHTTPAssistFuncs(t *testing.T) {
 	tmplfncs := FormatCode(templates.HTTPAssistFuncs)
 	// Get the source code for all the functions in the same source file as
 	// the BuildParamMap function

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -113,7 +113,7 @@ func EncodeHTTPSumZeroRequest(_ context.Context, r *http.Request, request interf
 	}
 }
 
-func _TestGenServerDecode(t *testing.T) {
+func TestGenServerDecode(t *testing.T) {
 	binding := &Binding{
 		Label:        "SumZero",
 		PathTemplate: "/sum/{a}",
@@ -169,16 +169,24 @@ func _TestGenServerDecode(t *testing.T) {
 // body. Primarily useful in a server.
 func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var req pb.SumRequest
-	err := json.NewDecoder(r.Body).Decode(&req)
-	// err = io.EOF if r.Body was empty
-	if err != nil && err != io.EOF {
-		return nil, errors.Wrap(err, "decoding body of http request")
+	buf, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot read body of http request")
+	}
+	if len(buf) > 0 {
+		if err = json.Unmarshal(buf, &req); err != nil {
+			const size = 8196
+			if len(buf) > size {
+				buf = buf[:size]
+			}
+			return nil, fmt.Errorf("request body '%s': cannot parse non-json request body", buf)
+		}
 	}
 
 	pathParams, err := PathParams(r.URL.Path, "/sum/{a}")
 	_ = pathParams
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't unmarshal path parameters")
+		return nil, errors.Wrap(err, "cannot unmarshal path parameters")
 	}
 
 	queryParams := r.URL.Query()


### PR DESCRIPTION
- [X] Change server http response content type to `"application/json; charset=utf-8"`
    - [x] Test http response content type
- [X] Update client to put response body in error if it is not a json response
    - [x] Test that response body is in the error
    - [X] Limit to 8KB (8196 bytes)
        - [x] Test with response body bigger than 8196 bytes.
- [X] Update server to put request body in error if the body is not json
    - [x] Test that request body is in the error
    - [X] Limit to 8KB (8196 bytes)
        - [x] Test with request body bigger than 8196 bytes.
